### PR TITLE
Enable full-text search in docs

### DIFF
--- a/__tests__/renderMarkdown.test.js
+++ b/__tests__/renderMarkdown.test.js
@@ -70,6 +70,8 @@ test('markdown files render with layout and appear in nav/search', async () => {
   const docs = search.docs.map(d => d.id);
   expect(docs).toContain('index.html');
   expect(docs).toContain('guide/install.html');
+  const installDoc = search.docs.find(d => d.id === 'guide/install.html');
+  expect(installDoc.body).toContain('Steps');
 
   fs.rmSync(tmp, { recursive: true, force: true });
 });

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -65,7 +65,8 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!doc) return;
       const a = document.createElement('a');
       a.href = doc.url;
-      a.innerHTML = '<strong>' + highlight(doc.title, q) + '</strong><br><small>' + highlight(doc.headings, q) + '</small>';
+      const snippet = doc.body ? doc.body.slice(0, 160) + (doc.body.length > 160 ? '...' : '') : '';
+      a.innerHTML = '<strong>' + highlight(doc.title, q) + '</strong><br><small>' + highlight(snippet, q) + '</small>';
       searchResults.appendChild(a);
     });
     searchResults.style.display = 'block';

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -142,8 +142,10 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
       const firstHeading = tokens.find(t => t.type === 'heading');
       const title = parsed.data.title || (firstHeading ? firstHeading.text : path.basename(rel, '.md'));
       const headings = tokens.filter(t => t.type === 'heading').map(t => t.text).join(' ');
+      const htmlBody = require('marked').parse(parsed.content || '');
+      const bodyText = htmlBody.replace(/<[^>]+>/g, ' ');
       pages.push({ file: rel, data: { ...parsed.data, title } });
-      searchDocs.push({ id: rel.replace(/\.md$/, '.html'), url: '/' + rel.replace(/\.md$/, '.html'), title, headings });
+      searchDocs.push({ id: rel.replace(/\.md$/, '.html'), url: '/' + rel.replace(/\.md$/, '.html'), title, headings, body: bodyText });
     } else {
       assets.push(rel);
     }
@@ -158,6 +160,7 @@ async function generate({ contentDir = 'content', outputDir = '_site', configPat
     this.ref('id');
     this.field('title');
     this.field('headings');
+    this.field('body');
     searchDocs.forEach(d => this.add(d));
   });
   await fs.promises.writeFile(


### PR DESCRIPTION
## Summary
- index page body text in search index
- display snippet of matched text in search results
- assert that body text is present in search index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68701ce348b8832ba23743479126c25a