### PR TITLE
Update footer links structure

### DIFF
--- a/assets/theme.css
+++ b/assets/theme.css
@@ -93,12 +93,25 @@ main {
   text-align: center;
   padding: 1rem;
   background: var(--sidebar-bg);
+  position: relative;
 }
 .footer-links {
   margin-bottom: 0.5rem;
 }
 .footer-links a {
   margin: 0 0.5rem;
+  text-decoration: none;
+  color: var(--text-color);
+}
+.footer-permanent-links {
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.25rem;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+.footer-permanent-links a {
+  margin-left: 0.5rem;
   text-decoration: none;
   color: var(--text-color);
 }

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -7,7 +7,7 @@ navigation:
 
 footer:
   links:
-    - text: "GitHub"
-      url: "https://github.com/PR0M3TH3AN/Archivox"
-    - text: "Tip Jar"
-      url: "https://nostrtipjar.netlify.app/?n=npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx"
+    - text: "Custom Link 1"
+      url: "https://example.com"
+    - text: "Custom Link 2"
+      url: "https://example.com/other"

--- a/templates/partials/footer.njk
+++ b/templates/partials/footer.njk
@@ -7,4 +7,8 @@
     </nav>
   {% endif %}
   <p>&copy; {{ config.site.title }}</p>
+  <div class="footer-permanent-links">
+    <a href="https://github.com/PR0M3TH3AN/Archivox">GitHub</a>
+    <a href="https://nostrtipjar.netlify.app/?n=npub15jnttpymeytm80hatjqcvhhqhzrhx6gxp8pq0wn93rhnu8s9h9dsha32lx">Tip Jar</a>
+  </div>
 </footer>


### PR DESCRIPTION
## Summary
- rename example footer links
- add always-visible GitHub and tip jar links
- style permanent footer links to sit in lower-right corner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68701d6d9c30832baa1b4c7b33d2c33a