### PR TITLE
Improve mobile sidebar UX

### DIFF
--- a/__tests__/responsive.test.js
+++ b/__tests__/responsive.test.js
@@ -100,6 +100,19 @@ test('sidebar opens on small screens', async () => {
   expect(sidebarLeft).toBe('0px');
 });
 
+test('clicking outside closes sidebar on small screens', async () => {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 500, height: 800 });
+  await page.goto(`http://localhost:${port}/`);
+  await page.waitForSelector('#sidebar-toggle');
+  await page.click('#sidebar-toggle');
+  await new Promise(r => setTimeout(r, 300));
+  await page.click('main');
+  await new Promise(r => setTimeout(r, 300));
+  const bodyClass = await page.evaluate(() => document.body.classList.contains('sidebar-open'));
+  expect(bodyClass).toBe(false);
+});
+
 test('sidebar toggles on large screens', async () => {
   const page = await browser.newPage();
   await page.setViewport({ width: 1024, height: 800 });

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -23,7 +23,9 @@ body {
   align-items: center;
   padding: 0.5rem 1rem;
   background: var(--sidebar-bg);
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 1100;
 }
 .search-input {
   margin-left: auto;
@@ -116,6 +118,20 @@ main {
   margin-left: 0.5rem;
   text-decoration: none;
   color: var(--text-color);
+}
+
+.sidebar-overlay {
+  display: none;
+}
+body.sidebar-open .sidebar-overlay {
+  display: block;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 999;
 }
 @media (max-width: 768px) {
   .sidebar {

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -3,6 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const themeToggle = document.getElementById('theme-toggle');
   const searchInput = document.getElementById('search-input');
   const searchResults = document.getElementById('search-results');
+  const sidebar = document.getElementById('sidebar');
+  const sidebarOverlay = document.getElementById('sidebar-overlay');
   const root = document.documentElement;
 
   function setTheme(theme) {
@@ -18,6 +20,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   sidebarToggle?.addEventListener('click', () => {
     document.body.classList.toggle('sidebar-open');
+  });
+
+  sidebarOverlay?.addEventListener('click', () => {
+    document.body.classList.remove('sidebar-open');
   });
 
   themeToggle?.addEventListener('click', () => {
@@ -75,6 +81,15 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('click', e => {
     if (!searchResults.contains(e.target) && e.target !== searchInput) {
       searchResults.style.display = 'none';
+    }
+    if (
+      window.innerWidth <= 768 &&
+      document.body.classList.contains('sidebar-open') &&
+      sidebar &&
+      !sidebar.contains(e.target) &&
+      e.target !== sidebarToggle
+    ) {
+      document.body.classList.remove('sidebar-open');
     }
   });
 

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -8,6 +8,7 @@
 </head>
 <body>
   {% include "partials/header.njk" %}
+  <div id="sidebar-overlay" class="sidebar-overlay"></div>
   <div class="container">
     {% include "partials/sidebar.njk" %}
     <main id="content">


### PR DESCRIPTION
## Summary
- make header sticky with high z-index so mobile menu button stays above sidebar
- add overlay element and hide sidebar on outside click
- implement overlay styles for mobile
- ensure sidebar closes when clicking outside
- test closing sidebar by clicking main area

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68701f90b38c832b8985ec2d7aecb66f